### PR TITLE
Handle case where no singular values are bigger than cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Optimal Hard Threshold for Matrix Denoising
-*******************************************
+# Optimal Hard Threshold for Matrix Denoising
 
 Off-the-shelf method for determining the optimal singular value truncation
 (hard threshold) for matrix denoising.
@@ -7,13 +6,12 @@ Off-the-shelf method for determining the optimal singular value truncation
 The method gives the optimal location both in the case of the known or unknown
 noise level.
 
-Example
-*******
+## Example
+
 ![example](https://raw.githubusercontent.com/Benli11/data/master/img/optHT2.png)
 ![example2](https://raw.githubusercontent.com/Benli11/data/master/img/optHT3.png)
 
-Reproduce the example
-*********************
+## Reproduce the example
 
 Create some data:
 
@@ -83,23 +81,22 @@ plt.axvline(k, c='r', linewidth=2, linestyle='--')
 plt.show()
 ```
 
-Authors & Acknowledgments
-*****
+## Authors & Acknowledgments
 
 * Thanks to Steven Dahdah for refactoring the code into a Python package.
 * Thanks to Bill Tubbs for style edits and a few typo corrections.
 * Thanks to  @nish-ant for adding fixes to make the code Python 3 compatible.
 
 
-Notes
-*****
-* Code is adapted from Matan Gavish and David L. Donoho, see [1].
+## Notes
+
+* Code is adapted from Matan Gavish and David L. Donoho, see [^1].
 Corresponding MATLAB code can be found
 [here](https://purl.stanford.edu/vg705qn9070)
 
-References
-**********
-[1] Gavish, Matan, and David L. Donoho.
+## References
+
+[^1] Gavish, Matan, and David L. Donoho.
 "The optimal hard threshold for singular values is 4/sqrt(3)"
 IEEE Transactions on Information Theory 60.8 (2014): 5040-5053.
 http://arxiv.org/abs/1305.5870

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ plt.show()
 
 ## Notes
 
-* Code is adapted from Matan Gavish and David L. Donoho, see [^1].
+* Code is adapted from Matan Gavish and David L. Donoho, see [1].
 Corresponding MATLAB code can be found
 [here](https://purl.stanford.edu/vg705qn9070)
 
 ## References
 
-[^1] Gavish, Matan, and David L. Donoho.
+[1] Gavish, Matan, and David L. Donoho.
 "The optimal hard threshold for singular values is 4/sqrt(3)"
 IEEE Transactions on Information Theory 60.8 (2014): 5040-5053.
 http://arxiv.org/abs/1305.5870

--- a/optht/optht.py
+++ b/optht/optht.py
@@ -79,7 +79,11 @@ def optht(beta, sv, sigma=None):
     log.info(f'`w(beta)` value: {coef}')
     log.info('Cutoff value: {cutoff}')
     # Compute and return rank
-    k = np.max(np.where(sv > cutoff)) + 1
+    greater_than_cutoff = np.where(sv > cutoff)
+    if greater_than_cutoff[0].size > 0:
+        k = np.max(greater_than_cutoff) + 1
+    else:
+        k = 0
     log.info(f'Target rank: {k}')
     return k
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 matplotlib
+pytest

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setuptools.setup(
     description='Optimal hard threshold for matrix denoising',
     long_description=readme,
     long_description_content_type="text/markdown",
-    author='N. Benjamin Erichson, Steven Dahdah',
-    author_email='erichson@berkeley.edu, Steven.Dahdah@mail.mcgill.ca',
+    author=('N. Benjamin Erichson', 'Steven Dahdah'),
+    author_email=('erichson@berkeley.edu', 'steven.dahdah@mail.mcgill.ca'),
     url='https://github.com/erichson/optht',
     project_urls={
         "Bug Tracker": "https://github.com/erichson/optht/issues",


### PR DESCRIPTION
I ran into a weird edge case where none of my singular values were bigger than the cutoff. Handled that case here without raising an exception.

Also fixed the README and setup.py syntax.

The LICENSE file says this repo is BSD, but the setup.py/PyPI say this repo is GPL. Which is it?